### PR TITLE
grmtweak

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,4 +32,4 @@ def dashboard():
 
 if __name__ == "__main__":
     from waitress import serve
-    serve(app, host="0.0.0.0", port=8080)
+    serve(app, host="0.0.0.0", port=8081)

--- a/app.py
+++ b/app.py
@@ -32,4 +32,5 @@ def dashboard():
 
 if __name__ == "__main__":
     from waitress import serve
-    serve(app, host="0.0.0.0", port=8081)
+    serve(app, host="0.0.0.0", port=8080)
+    # TODO: Add an CLI arg option to specify port, debug mode. etc

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from flask import Flask, redirect, url_for, render_template
-from gh import get_changelog, get_incident_history, get_latest_incident, get_blogfeed, get_github_status
+from gh import get_changelog, get_incident_history, get_latest_incident, get_blogfeed, get_github_status, get_maintenance_events
 from datetime import datetime
 
 app = Flask(__name__)
@@ -18,6 +18,7 @@ def dashboard():
     blogfeed = get_blogfeed()
     now = datetime.now()
     time = now.strftime("%a, %-d %b %Y %-H:%M:%S UTC")
+    events = get_maintenance_events()
 
     return render_template("dashboard.html",
                            changelogs=changelogs,
@@ -25,7 +26,8 @@ def dashboard():
                            status=status,
                            incidentHistory=incidentHistory,
                            blogfeed=blogfeed,
-                           time=time)
+                           time=time,
+                           events=events)
 
 
 if __name__ == "__main__":

--- a/gh.py
+++ b/gh.py
@@ -27,9 +27,7 @@ def get_github_status():
 
     raw = soup.find('h2', {'class': 'status font-large'})
     status = raw.get_text().strip()
-    print(status)
     return status
-    
 
 def get_latest_incident():
     a = feedparser.parse('https://www.githubstatus.com/history.rss')

--- a/gh.py
+++ b/gh.py
@@ -60,8 +60,10 @@ def get_maintenance_events():
             endtime = entry['maintenanceenddate']
             link = entry['link']
             checktime = datetime.strptime(endtime, '%a, %d %b %Y %H:%M:%S +0000').timestamp()
-#            print(checktime, current)
+
+# TODO: Implement mechanism to determine if maintenance is still scheduled or already complete
 #            if checktime < current:
+
             events["title"].append(title[:])
             events["endtime"].append(endtime[:])
             events["link"].append(link[:])

--- a/gh.py
+++ b/gh.py
@@ -25,14 +25,11 @@ def get_github_status():
     html = urlopen('https://www.githubstatus.com/')
     soup = BeautifulSoup(html, 'html.parser')
 
-    raw = soup.find('span', {'class': 'status font-large'})
+    raw = soup.find('h2', {'class': 'status font-large'})
+    status = raw.get_text().strip()
+    print(status)
+    return status
     
-    if raw is None:
-        status = "Incident occurring 🟠"
-        return status
-    else:
-        status = raw.text.lstrip()
-        return status
 
 def get_latest_incident():
     a = feedparser.parse('https://www.githubstatus.com/history.rss')

--- a/gh.py
+++ b/gh.py
@@ -32,15 +32,50 @@ def get_github_status():
 def get_latest_incident():
     a = feedparser.parse('https://www.githubstatus.com/history.rss')
     incident = dict(title=[], published=[], link=[])
-    title = a['entries'][0]['title']
-    published = a['entries'][0]['published']
-    link = a['entries'][0]['link']
+    i = 0
+    for entry in a.entries:
+        if 'maintenanceenddate' in entry:
+            i += 1
+            continue
+        else:
 
-    incident["title"].append(title[:])
-    incident["published"].append(published[:])
-    incident["link"].append(link[:])
+            title = a['entries'][i]['title']
+            published = a['entries'][i]['published']
+            link = a['entries'][i]['link']
 
-    return incident
+            incident["title"].append(title[:])
+            incident["published"].append(published[:])
+            incident["link"].append(link[:])
+
+            return incident
+
+def get_maintenance_events():
+    a = feedparser.parse('https://www.githubstatus.com/history.rss')
+    events = dict(title=[], endtime=[], link=[])
+    date = datetime.now()
+    current = date.timestamp()
+    for entry in a.entries:
+        if 'maintenanceenddate' in entry:
+            title = entry['title']
+            endtime = entry['maintenanceenddate']
+            link = entry['link']
+            checktime = datetime.strptime(endtime, '%a, %d %b %Y %H:%M:%S +0000').timestamp()
+#            print(checktime, current)
+#            if checktime < current:
+            events["title"].append(title[:])
+            events["endtime"].append(endtime[:])
+            events["link"].append(link[:])
+            return events
+
+
+    else:
+        events = 'No maintenance events found'
+        return events
+        pass
+
+
+
+
 
 def get_incident_history():
     a = feedparser.parse('https://www.githubstatus.com/history.rss')
@@ -64,7 +99,6 @@ def get_blogfeed():
         title = b['entries'][i]['title']
         published = b['entries'][i]['published']
         link = b['entries'][i]['link']
-#        if 'Availability' in title:
 
         blogfeed["title"].append(title[:])
         blogfeed["published"].append(published[:])
@@ -84,5 +118,6 @@ def main():
     get_incident_history()
     get_blogfeed()
     get_changelog()
+    get_maintenance_events()
 
 main()

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -18,6 +18,12 @@
         <p>{{ incident.published[0] }}</p>
         <p><a href="{{ incident.link[0] }}" target="_blank">Incident Link</a></p>
 
+        <div class="horizontal-divider"></div> <!-- horidividal-->
+        <p> SCHEDULED MAINTENANCE </p>
+        <h4> {{ events.title[0] }} </h4>
+        <p>{{ events.endtime[0] }}</p>
+        <p><a href="{{ events.link[0] }}" target="_blank">Event Link</a></p>
+
 
         <div class="horizontal-divider"></div> <!-- horidividal-->
 
@@ -44,6 +50,8 @@
         {% endfor %}
     </div>
     <div class="container">
+    <div class="horizontal-divider"></div> <!-- horidividal-->
+
 <p> BLOG FEED </p>
         {% for n in range(blogfeed.title|length) %}
         <h4>{{ blogfeed.title[n] }}</h4>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -8,15 +8,11 @@
     <div class="container">
 
 
-       {% if status == 'All Systems Operational' %}
+        <h3><a href="https://www.githubstatus.com/" target="_blank">🪜</a> {{ status }}</h3>
+        
 
-        <h3> 🟢 {{ status }} </h3>
-
-        {% else %}
-
-        <h2>{{ status }}</h2>
+       
         <div class="horizontal-divider"></div> <!-- horidividal-->
-        {% endif %}
         <p> LAST INCIDENT</p>
         <h4> {{ incident.title[0] }} </h4>
         <p>{{ incident.published[0] }}</p>
@@ -24,6 +20,7 @@
 
 
         <div class="horizontal-divider"></div> <!-- horidividal-->
+
 <p> INCIDENT HISTORY </p>
     {% for n in range(incidentHistory.title|length) %}
 


### PR DESCRIPTION
Keep it simple:

- Display status directly from githubstatus rather than unrobust logic to determine incident status
- ladder link to githubstatus for source of truth

New feature:
- maintenance events are now a thing and they aren't incidents so act appropriately on these and add relevant jinja2 distinction